### PR TITLE
Evaluate plot html reference before concatenating (cat)

### DIFF
--- a/inst/rmarkdown/report.Rmd
+++ b/inst/rmarkdown/report.Rmd
@@ -382,6 +382,7 @@ plots <- list.files("/mnt/EXT4/t/report_files/figure-html/")
 
 for(i in plots){
   filename <- file.path("report_files/figure-html/", i)
-  cat("![text](",filename,")")
+  plot_ref <- paste0("![text](", filename, ")")
+  cat(plot_ref)
 }
 ```


### PR DESCRIPTION
Addresses reported error when compiling report from LaTex:

```
Warning in parse_packages(logfile, quiet = !verbose) :

  Failed to find a package that contains ",filename,"

! LaTeX Error: File `",filename,"' not found.
```
